### PR TITLE
Add C++ photo editor prototype

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.10)
+project(PhotoEditor)
+set(CMAKE_CXX_STANDARD 17)
+find_package(OpenCV REQUIRED)
+include_directories(${OpenCV_INCLUDE_DIRS})
+add_executable(photo_editor src/main.cpp)
+target_link_libraries(photo_editor ${OpenCV_LIBS})

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1,0 +1,18 @@
+# User Manual
+
+This project is an early prototype. Current capabilities include:
+
+- Loading a catalogue (folder) of images.
+- Adjusting brightness and basic HSL controls.
+- Saving the processed image to `output.jpg`.
+
+The code contains placeholders for future features:
+
+- Mask adjustments
+- AI metadata insertion
+- AI remove tools
+- Generative AI
+- Professional denoise
+- Social media sharing
+
+Contributions welcome!

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# GPT_C
-C++
+# Photo Editor
+
+This is a simple C++ photo editing tool demonstrating a catalogue loader and basic adjustments using OpenCV. Features such as AI tools and advanced editing are represented as placeholders for future work.
+
+## Building
+
+Ensure CMake and OpenCV are installed. Then run:
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+```
+
+Run the program by pointing it at a folder of images:
+
+```bash
+./photo_editor ../samples
+```

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,104 @@
+#include <opencv2/opencv.hpp>
+#include <filesystem>
+#include <iostream>
+#include <vector>
+#include <string>
+
+namespace fs = std::filesystem;
+
+class Image {
+public:
+    cv::Mat data;
+    std::string path;
+    Image(const std::string& p) : path(p) {
+        data = cv::imread(p, cv::IMREAD_UNCHANGED);
+        if (data.empty()) {
+            std::cerr << "Failed to load: " << p << std::endl;
+        }
+    }
+};
+
+class Catalogue {
+public:
+    std::vector<Image> images;
+    void load(const std::string& folder) {
+        images.clear();
+        for (const auto& entry : fs::directory_iterator(folder)) {
+            if (entry.is_regular_file()) {
+                images.emplace_back(entry.path().string());
+            }
+        }
+        std::cout << "Loaded " << images.size() << " files from " << folder << std::endl;
+    }
+};
+
+// Basic brightness adjustment
+void adjustBrightness(Image& img, int delta) {
+    cv::Mat tmp;
+    img.data.convertTo(tmp, -1, 1, delta);
+    img.data = tmp;
+}
+
+// Hue saturation lightness simple implementation
+void adjustHSL(Image& img, int hue, int sat, int light) {
+    cv::Mat hsv;
+    cv::cvtColor(img.data, hsv, cv::COLOR_BGR2HSV);
+    for (int y = 0; y < hsv.rows; ++y) {
+        for (int x = 0; x < hsv.cols; ++x) {
+            cv::Vec3b& pixel = hsv.at<cv::Vec3b>(y, x);
+            pixel[0] = cv::saturate_cast<uchar>(pixel[0] + hue);
+            pixel[1] = cv::saturate_cast<uchar>(pixel[1] + sat);
+            pixel[2] = cv::saturate_cast<uchar>(pixel[2] + light);
+        }
+    }
+    cv::cvtColor(hsv, img.data, cv::COLOR_HSV2BGR);
+}
+
+// Placeholder for mask adjustments
+void maskAdjust(Image& img) {
+    // TODO: Implement mask adjustments
+}
+
+// Placeholder for AI metadata insertion
+void aiMetadata(Image& img) {
+    // TODO: Use AI to generate metadata
+}
+
+// Placeholder for AI remove tools
+void aiRemove(Image& img) {
+    // TODO: AI object removal
+}
+
+// Placeholder for generative AI
+void generativeAI(Image& img, const std::string& prompt) {
+    // TODO: Generate new content based on prompt
+}
+
+// Placeholder for professional denoise
+void denoise(Image& img) {
+    // TODO: Advanced denoising
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cout << "Usage: " << argv[0] << " <catalogue folder>" << std::endl;
+        return 0;
+    }
+
+    Catalogue cat;
+    cat.load(argv[1]);
+
+    if (cat.images.empty()) {
+        return 0;
+    }
+
+    Image& img = cat.images[0];
+    adjustBrightness(img, 50);
+    adjustHSL(img, 10, 10, 10);
+    aiMetadata(img); // placeholder
+    denoise(img);    // placeholder
+    cv::imwrite("output.jpg", img.data);
+
+    std::cout << "Saved output.jpg" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add CMake build with OpenCV
- implement `main.cpp` with basic brightness and HSL adjustment and placeholders for advanced features
- document build steps and simple usage
- create a brief manual describing current and planned capabilities

## Testing
- `cmake ..` *(fails: could not find OpenCV)*

------
https://chatgpt.com/codex/tasks/task_e_68597eea581083278db81e35a23ca19e