### PR TITLE
Add simple GUI for photo editing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.10)
+project(PhotoEditor)
+set(CMAKE_CXX_STANDARD 17)
+find_package(OpenCV REQUIRED)
+include_directories(${OpenCV_INCLUDE_DIRS})
+add_executable(photo_editor src/main.cpp)
+target_link_libraries(photo_editor ${OpenCV_LIBS})

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1,0 +1,35 @@
+# User Manual
+
+This project is an early prototype. Current capabilities include:
+
+- Loading one or more folders of images (JPEG/PNG/DNG)
+- Interactive brightness and HSL editing via GUI sliders
+- Simple rectangular mask adjustment
+- Saving adjustments as `preset.txt`
+- Culling unwanted images
+- Processed images are written as `edited_#.jpg`
+- AI metadata generation writes a `.meta` file next to each image
+- Object removal uses a simple inpainting tool
+- Generative overlay prints the prompt text onto the image
+- Denoise filter reduces noise using OpenCV
+
+## Using the GUI
+
+When an image loads a window titled **Photo Editor** appears with sliders for brightness, hue, saturation and lightness. Keyboard shortcuts include:
+
+- `n` or `Esc` – move to the next image
+- `q` – quit the session
+- `d` – denoise the current photo
+- `r` – remove a region by entering coordinates in the console
+- `m` – apply a brightness mask to a region
+- `i` – write AI metadata to a `.meta` file
+- `g` – generate text overlay from a prompt
+- `s` – save slider positions as the preset
+- `l` – load the preset
+- `c` – mark the photo as culled
+
+The code contains placeholders for future features:
+
+- Advanced mask tools
+
+Contributions welcome!

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# GPT_C
-C++
+# Photo Editor
+
+This is a small C++ photo editing prototype built with OpenCV. It can load images from one or more folders, perform interactive edits and save the results. Advanced AI features are represented as placeholders for future work.
+
+Current features:
+
+- Load JPEG, PNG and DNG files from multiple catalogues
+- Interactive brightness and HSL controls via GUI sliders
+- Simple rectangular masking
+- Ability to cull unwanted photos
+- Preset save/load support (stored in `preset.txt`)
+- AI metadata generation
+- Object removal via inpainting
+- Prompt-based generative overlay
+- Basic denoise filter
+
+## Building
+
+Ensure CMake and OpenCV are installed. Then run:
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+```
+
+Run the program by pointing it at one or more folders of images. For each image a window will appear with sliders to tweak brightness and HSL values. Keyboard shortcuts allow applying masks and other tools. Edits are saved to files prefixed with `edited_`.
+
+```bash
+./photo_editor ../samples ../more_images
+```

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,279 @@
+#include <opencv2/opencv.hpp>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <vector>
+#include <string>
+
+namespace fs = std::filesystem;
+
+struct Image {
+    cv::Mat data;
+    std::string path;
+    bool edited = false;
+    bool culled = false;
+
+    Image(const std::string& p) : path(p) {
+        data = cv::imread(p, cv::IMREAD_UNCHANGED);
+        if (data.empty()) {
+            std::cerr << "Failed to load: " << p << std::endl;
+        }
+    }
+};
+
+struct Preset {
+    int brightness = 0;
+    int hue = 0;
+    int saturation = 0;
+    int light = 0;
+};
+
+class Catalogue {
+public:
+    std::vector<Image> images;
+
+    void loadFolder(const std::string& folder) {
+        for (const auto& entry : fs::directory_iterator(folder)) {
+            if (entry.is_regular_file()) {
+                images.emplace_back(entry.path().string());
+            }
+        }
+        std::cout << "Loaded " << images.size() << " files from " << folder << std::endl;
+    }
+
+    void load(const std::vector<std::string>& folders) {
+        images.clear();
+        for (const auto& f : folders) {
+            if (fs::exists(f) && fs::is_directory(f)) {
+                loadFolder(f);
+            }
+        }
+    }
+};
+
+// Basic brightness adjustment
+void adjustBrightness(cv::Mat& mat, int delta) {
+    cv::Mat tmp;
+    mat.convertTo(tmp, -1, 1, delta);
+    mat = tmp;
+}
+
+void adjustBrightness(Image& img, int delta) {
+    adjustBrightness(img.data, delta);
+    img.edited = true;
+}
+
+// Hue saturation lightness simple implementation
+void adjustHSL(cv::Mat& mat, int hue, int sat, int light) {
+    cv::Mat hsv;
+    cv::cvtColor(mat, hsv, cv::COLOR_BGR2HSV);
+    for (int y = 0; y < hsv.rows; ++y) {
+        for (int x = 0; x < hsv.cols; ++x) {
+            cv::Vec3b& pixel = hsv.at<cv::Vec3b>(y, x);
+            pixel[0] = cv::saturate_cast<uchar>(pixel[0] + hue);
+            pixel[1] = cv::saturate_cast<uchar>(pixel[1] + sat);
+            pixel[2] = cv::saturate_cast<uchar>(pixel[2] + light);
+        }
+    }
+    cv::cvtColor(hsv, mat, cv::COLOR_HSV2BGR);
+}
+
+void adjustHSL(Image& img, int hue, int sat, int light) {
+    adjustHSL(img.data, hue, sat, light);
+    img.edited = true;
+}
+
+// Simple rectangular mask to brighten region
+void maskAdjust(Image& img, const cv::Rect& area, int delta) {
+    cv::Mat roi = img.data(area);
+    cv::Mat tmp;
+    roi.convertTo(tmp, -1, 1, delta);
+    tmp.copyTo(roi);
+    img.edited = true;
+}
+
+// AI metadata insertion using simple color analysis
+void aiMetadata(Image& img) {
+    cv::Scalar mean = cv::mean(img.data);
+    std::string outFile = img.path + ".meta";
+    std::ofstream out(outFile);
+    if (out.is_open()) {
+        out << "mean_b=" << mean[0] << "\n";
+        out << "mean_g=" << mean[1] << "\n";
+        out << "mean_r=" << mean[2] << "\n";
+    }
+}
+
+// Basic remove tool using inpainting over a user selected rectangle
+void aiRemove(Image& img) {
+    int x, y, w, h;
+    std::cout << "remove x y w h: ";
+    std::cin >> x >> y >> w >> h;
+    cv::Mat mask = cv::Mat::zeros(img.data.size(), CV_8U);
+    cv::rectangle(mask, cv::Rect(x, y, w, h), cv::Scalar(255), cv::FILLED);
+    cv::inpaint(img.data, mask, img.data, 3, cv::INPAINT_TELEA);
+    img.edited = true;
+}
+
+// Generative AI placeholder that overlays the prompt text
+void generativeAI(Image& img, const std::string& prompt) {
+    cv::putText(img.data, prompt, {10, img.data.rows / 2},
+                cv::FONT_HERSHEY_SIMPLEX, 1.0, {255, 255, 255}, 2);
+    img.edited = true;
+}
+
+// Professional denoise using OpenCV fastNlMeansDenoising
+void denoise(Image& img) {
+    cv::Mat tmp;
+    cv::fastNlMeansDenoisingColored(img.data, tmp, 10, 10, 7, 21);
+    img.data = tmp;
+    img.edited = true;
+}
+
+bool savePreset(const Preset& p, const std::string& file) {
+    std::ofstream out(file);
+    if (!out.is_open()) return false;
+    out << p.brightness << " " << p.hue << " " << p.saturation << " " << p.light;
+    return true;
+}
+
+bool loadPreset(Preset& p, const std::string& file) {
+    std::ifstream in(file);
+    if (!in.is_open()) return false;
+    in >> p.brightness >> p.hue >> p.saturation >> p.light;
+    return true;
+}
+
+struct GUIState {
+    cv::Mat original;
+    cv::Mat display;
+    int bright = 100;
+    int hue = 180;
+    int sat = 100;
+    int light = 100;
+};
+
+static void updateDisplay(GUIState* st) {
+    st->original.copyTo(st->display);
+    adjustBrightness(st->display, st->bright - 100);
+    adjustHSL(st->display, st->hue - 180, st->sat - 100, st->light - 100);
+    cv::imshow("Photo Editor", st->display);
+}
+
+static void onTrack(int, void* userdata) {
+    GUIState* st = reinterpret_cast<GUIState*>(userdata);
+    updateDisplay(st);
+}
+
+// Edit image via simple GUI. Returns false if user quit.
+bool editImageGUI(Image& img, Preset& preset) {
+    GUIState st;
+    st.original = img.data.clone();
+    st.display = img.data.clone();
+    st.bright = preset.brightness + 100;
+    st.hue = preset.hue + 180;
+    st.sat = preset.saturation + 100;
+    st.light = preset.light + 100;
+
+    cv::namedWindow("Photo Editor", cv::WINDOW_NORMAL);
+    cv::createTrackbar("Brightness", "Photo Editor", &st.bright, 200, onTrack, &st);
+    cv::createTrackbar("Hue", "Photo Editor", &st.hue, 360, onTrack, &st);
+    cv::createTrackbar("Saturation", "Photo Editor", &st.sat, 200, onTrack, &st);
+    cv::createTrackbar("Light", "Photo Editor", &st.light, 200, onTrack, &st);
+
+    updateDisplay(&st);
+
+    bool quitAll = false;
+    while (true) {
+        int k = cv::waitKey(20);
+        if (k == 'n' || k == 27) { // next or ESC
+            break;
+        } else if (k == 'q') {
+            quitAll = true;
+            break;
+        } else if (k == 'd') {
+            denoise(img);
+            st.original = img.data.clone();
+            updateDisplay(&st);
+        } else if (k == 'i') {
+            aiMetadata(img);
+        } else if (k == 'g') {
+            std::string prompt; std::cout << "prompt: "; std::getline(std::cin, prompt); generativeAI(img, prompt);
+            st.original = img.data.clone();
+            updateDisplay(&st);
+        } else if (k == 'r') {
+            aiRemove(img);
+            st.original = img.data.clone();
+            updateDisplay(&st);
+        } else if (k == 'm') {
+            int x,y,w,h,d; std::cout << "x y w h delta: "; std::cin >> x >> y >> w >> h >> d; maskAdjust(img,{x,y,w,h},d); std::cin.ignore();
+            st.original = img.data.clone();
+            updateDisplay(&st);
+        } else if (k == 's') {
+            preset.brightness = st.bright - 100;
+            preset.hue = st.hue - 180;
+            preset.saturation = st.sat - 100;
+            preset.light = st.light - 100;
+            savePreset(preset, "preset.txt");
+        } else if (k == 'l') {
+            if (loadPreset(preset, "preset.txt")) {
+                st.bright = preset.brightness + 100;
+                st.hue = preset.hue + 180;
+                st.sat = preset.saturation + 100;
+                st.light = preset.light + 100;
+                updateDisplay(&st);
+            }
+        } else if (k == 'c') {
+            img.culled = true; break;
+        }
+    }
+    cv::destroyWindow("Photo Editor");
+
+    if (!img.culled) {
+        preset.brightness = st.bright - 100;
+        preset.hue = st.hue - 180;
+        preset.saturation = st.sat - 100;
+        preset.light = st.light - 100;
+        st.display.copyTo(img.data);
+        img.edited = true;
+    }
+    return !quitAll;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cout << "Usage: " << argv[0] << " <catalogue folders...>" << std::endl;
+        return 0;
+    }
+
+    std::vector<std::string> folders;
+    for (int i = 1; i < argc; ++i)
+        folders.push_back(argv[i]);
+
+    Catalogue cat;
+    cat.load(folders);
+
+    if (cat.images.empty()) {
+        return 0;
+    }
+
+    Preset preset;
+    loadPreset(preset, "preset.txt"); // ignore result
+
+    bool cont = true;
+    for (size_t idx = 0; idx < cat.images.size() && cont; ++idx) {
+        Image& img = cat.images[idx];
+        std::cout << "Editing " << img.path << std::endl;
+        cont = editImageGUI(img, preset);
+    }
+
+    int count = 0;
+    for (const auto& img : cat.images) {
+        if (!img.culled && img.edited) {
+            cv::imwrite("edited_" + std::to_string(count++) + ".jpg", img.data);
+        }
+    }
+
+    std::cout << "Processed " << count << " images" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement OpenCV GUI with brightness and HSL sliders
- keep keyboard shortcuts for existing tools
- update README and MANUAL with GUI information

## Testing
- `cmake ..` *(fails: Could not find OpenCV)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68597eea581083278db81e35a23ca19e